### PR TITLE
Add rsync to china server on commit

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,57 @@
+name: sync-to-china
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency: 
+  group: sync # only 1 sync at a time
+
+jobs:
+  build:
+    env:
+      LARGE_FILE_REPOSITORY: "pkegg/PortMaster-Hosting"
+      LARGE_FILE_TAG: "large-files"
+      RSYNC_HOST: 139.196.213.206
+      
+      #RSYNC_PATH *must* end in a / or it will not work
+      RSYNC_PATH: /home/kreal/public/arkos/ports/
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: hmarr/debug-action@v2
+        name: "debug: ${{github.event_name}}"
+      - name: Valid proper secrets set
+        run: |
+          valid=true
+          if [[ -z "${{ secrets.RSYNC_USER }}" ]]; then
+            echo "Please specify a secret: RSYNC_USER for sync to run"
+            valid=false
+          fi
+          if [[ -z "${{ secrets.RSYNC_PASSWORD }}" ]]; then
+            echo "Please specify a secret: RSYNC_PASSWORD for sync to run"
+            valid=false
+          fi
+          if [[ "$valid" != "true" ]]; then
+            exit 1
+          fi
+      - uses: actions/checkout@v2
+      - uses: robinraju/release-downloader@v1.2
+        with:
+          repository: "${{env.LARGE_FILE_REPOSITORY}}"
+          tag: "${{env.LARGE_FILE_TAG}}"
+          fileName: "*"
+
+      - name: rsync files
+        run: |
+          rsync_user="${{ secrets.RSYNC_USER }}"
+          rsync_password="${{ secrets.RSYNC_PASSWORD }}"
+          rsync_path="${{ env.RSYNC_PATH }}"
+          rsync_host="${{ env.RSYNC_HOST }}"
+
+          sshpass -p "$rsync_password" \
+            rsync -avz --progress --no-times --no-perms --no-group --no-owner --partial --fuzzy \
+              --exclude ".*" \
+              -e "ssh -oStrictHostKeyChecking=no" \
+              ./ $rsync_user@$rsync_host:$rsync_path


### PR DESCRIPTION
# Summary
New GitHub Actions logic run on commit:
- Clone repo for zips less than 100mb
- Fetch 'large' files release for zips greater than 100mb+ (SuperTux, UQM, srb2kart, srb2).
  -  The 'large-files' GitHub Release is here for now: https://github.com/pkegg/PortMaster-Hosting/releases/tag/large-files.  NOTE: this release is manually created/updated similar to how china server is manually updated today.
- Sync all above files to china server.


This makes is so that the china server is just a 'mirror' of what's in the GitHub repository (+ large files which are also in GitHub).  Having everything come from GitHub is advantageous for future GitHub build automation (and is simpler than existing process in the mean time).

# Impact to developers updating zips
Mostly for: @christianhaitian / @romadu
 - After this change, updating the china server directly should no longer be required.
   - FYI: I pulled in the latest changes to srb2kart.zip from earlier today.
   - Files committed to git will be automatially synced.
   - No files will be **deleted** from china server for safety (though existing files will be replaced).
 - **When 100mb+ zip files are updated they must be updated in the [large files](https://github.com/pkegg/PortMaster-Hosting/releases/tag/large-files) release**.  Changes made to exising .zip files on the china server will be **overwritten** when the sync runs.
   - After updating a zip in the large-files release, a sync can be run in the GitHub UI to update china server.  "Actions -> sync-to-china -> Run Workflow"
  - NOTE: I have added `christianhaitian` and `romadu` to the users of PortMaster-Hosting.  I think it is probably best to move PortMaster-Hosting to christianhaitian account for consistency.

# GitHub Secrets Required in PortMaster repo
Mostly for: @christianhaitian 

In order to not leak the user/password in build logs, they are provided as a 'repository secret' (Settings -> Secrets -> Add Repository Secret).

This means in christianhaitian/PortMaster the following secrets must be set or the build will error.
`RSYNC_USER` - the ssh user used to run the rsync
`RSYNC_PASSWORD` - the ssh password for the above use to run rsync

# Example Sync
https://github.com/pkegg/PortMaster/actions/runs/1541953621