### PR TITLE
Single quote var to avoid variable interpolation

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -46,7 +46,7 @@ jobs:
       - name: rsync files
         run: |
           rsync_user="${{ secrets.RSYNC_USER }}"
-          rsync_password="${{ secrets.RSYNC_PASSWORD }}"
+          rsync_password='${{ secrets.RSYNC_PASSWORD }}'
           rsync_path="${{ env.RSYNC_PATH }}"
           rsync_host="${{ env.RSYNC_HOST }}"
 


### PR DESCRIPTION
Sync variable was put in double quotes so bash will interpolate variables (`$`, etc) which is not wanted.

Valid run: https://github.com/pkegg/PortMaster/runs/4446601679?check_suite_focus=true