### PR TITLE
Rigth Integration of MAX/MAX2 devices with RetroOz

### DIFF
--- a/PortMaster/control.txt
+++ b/PortMaster/control.txt
@@ -71,19 +71,24 @@ elif [[ -e "/dev/input/by-path/platform-odroidgo2-joypad-event-joystick" ]]; the
 elif [[ -e "/dev/input/by-path/platform-odroidgo3-joypad-event-joystick" ]]; then
       DEVICE="190000004b4800000011000000010000"
       param_device="ogs"
-	  if [ "$(cat ~/.config/.OS)" == "ArkOS" ] && [ "$(cat ~/.config/.DEVICE)" == "RGB10MAX" ]; then
-		sed -i 's/back:b12,guide:b16,start:b13/back:b14,guide:b12,start:b15/' ${controlfolder}/gamecontrollerdb.txt
-		sed -i 's/leftstick:b14,rightstick:b15/leftstick:b16,rightstick:b17/' ${controlfolder}/gamecontrollerdb.txt
+      if [ "$(cat ~/.config/.OS)" == "ArkOS" ] && [ "$(cat ~/.config/.DEVICE)" == "RGB10MAX" ]; then
+        sed -i 's/back:b12,guide:b16,start:b13/back:b14,guide:b12,start:b15/' ${controlfolder}/gamecontrollerdb.txt
+        sed -i 's/leftstick:b14,rightstick:b15/leftstick:b16,rightstick:b17/' ${controlfolder}/gamecontrollerdb.txt
         export HOTKEY="guide"
-	  fi
+      fi
       if [[ -e "/opt/.retrooz/device" ]]; then
-        retrooztest="$(cat /opt/.retrooz/device)"
-        if [[ "$retrooztest" == *"rgb10max2native"* ]]; then
-          param_device="rgb10max2native"
-        elif [[ "$retrooztest" == *"rgb10max2top"* ]]; then
-          param_device="rgb10max2top"
-        else 
-          param_device="ogs"
+        param_device="$(cat /opt/.retrooz/device)"
+        if [[ "$param_device" == *"rgb10max2native"* ]]; then
+          param_device="rgb10maxnative"
+        elif [[ "$param_device" == *"rgb10max2top"* ]]; then
+          param_device="rgb10maxtop"
+        fi
+        if [[ "$param_device" == *"rgb10maxnative"* ]]; then
+          sed -i 's/back:b12/back:b14/; s/guide:b16/guide:b12/; s/guide:b14/guide:b12/; s/start:b13/start:b15/; s/leftstick:b14/leftstick:b16/; s/rightstick:b15/rightstick:b17/' ${controlfolder}/gamecontrollerdb.txt
+        elif [[ "$param_device" == *"rgb10maxtop"* ]]; then
+          sed -i 's/back:b14/back:b12/; s/guide:b12/guide:b14/; s/guide:b16/guide:b14/; s/start:b15/start:b13/; s/leftstick:b14/leftstick:b16/; s/rightstick:b15/rightstick:b17/' ${controlfolder}/gamecontrollerdb.txt
+        elif [[ "$param_device" == *"ogs"* ]]; then
+          sed -i 's/back:b14/back:b12/; s/guide:b12/guide:b16/; s/guide:b14/guide:b16/; s/start:b15/start:b13/; s/leftstick:b16/leftstick:b14/; s/rightstick:b17/rightstick:b15/' ${controlfolder}/gamecontrollerdb.txt
         fi
       fi
 elif [[ -e "/dev/input/by-path/platform-gameforce-gamepad-event-joystick" ]]; then


### PR DESCRIPTION
Hi Christian,

Please, permiteme enviarte este PR que permite corregir la integracion de PortMaster con RetroOz.

With the last changes/updates of RetroOz, really, the MAX2 devices are the same as a MAX device.

Also, in RetroOz you can change the position of the buttons "select" and "start", then you need more changes on the "gamecontrollerdb.txt" file.

Bye and great work.