### PR TITLE
Add bugdom port for JELOS -> 552

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -24,7 +24,7 @@ Title="Blood ." Desc="Blood port based on EDuke32.  You'll need to add your own 
 
 Title="Blues_Brothers ." Desc="A rewrite of the Blues Brothers game engine developed by Titus Interactive.  Includes the demo files.  You can add your own full game Amiga or Dos files to the ports/bluesbrothers/gamedata folder." porter="Jetup" locat="Blues%20Brothers.zip" runtype="rtr"
 
-Title_F="Bugdom ." Desc="This is Pangea Software's Bugdom updated to run on modern operating systems. This version, at https://github.com/jorio/bugdom, is approved by Pangea Software. Use touchscreen to navigate UI." porter="brooksytech" locat="Bugdom.zip" runtype="rtr"
+Title_F="Bugdom ." Desc="This is Pangea Software's Bugdom updated to run on modern operating systems. Use the touchscreen to navigate the UI." porter="brooksytech" locat="Bugdom.zip" runtype="rtr"
 
 Title="Cannonball ." Desc="This is the libretro port of the OutRun game engine recreation written by Chris White in 2014.  Add the OutRun Revision B ROMs into /ports/cannonball/gamedata folder. " porter="Christian_Haitian" locat="Cannonball.zip"
 

--- a/ports.md
+++ b/ports.md
@@ -24,6 +24,8 @@ Title="Blood ." Desc="Blood port based on EDuke32.  You'll need to add your own 
 
 Title="Blues_Brothers ." Desc="A rewrite of the Blues Brothers game engine developed by Titus Interactive.  Includes the demo files.  You can add your own full game Amiga or Dos files to the ports/bluesbrothers/gamedata folder." porter="Jetup" locat="Blues%20Brothers.zip" runtype="rtr"
 
+Title_F="Bugdom ." Desc="This is Pangea Software's Bugdom updated to run on modern operating systems. This version, at https://github.com/jorio/bugdom, is approved by Pangea Software. Use touchscreen to navigate UI." porter="brooksytech" locat="Bugdom.zip" runtype="rtr"
+
 Title="Cannonball ." Desc="This is the libretro port of the OutRun game engine recreation written by Chris White in 2014.  Add the OutRun Revision B ROMs into /ports/cannonball/gamedata folder. " porter="Christian_Haitian" locat="Cannonball.zip"
 
 Title="Cave_Story_lr ." Desc="Cave Story using the Libretro Retroarch Nxengine core." porter="Christian_Haitian" locat="Cave%20Story.zip" runtype="rtr"


### PR DESCRIPTION
Wiki entry:

Bugdom
Instructions: Bugdom files are already included and ready to go. Just start Bugdom from Ports in the emulationstation menu. Use the touchscreen to navigate the UI. Currently only runs on the RG552 with Jelos installed. 
Notes: Thanks to Pangea Software for creating the game and publicly releasing the game files. Thanks to Jorio for porting the game engine to various platforms. https://github.com/jorio/Bugdom