### PR TITLE
Add Hexen 2 and Portal of Praevus

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -76,6 +76,8 @@ Title="Heart_of_Darkness ." Desc="Heart of Darkness using the hode reimplementat
 
 Title="Hex-A-Hop ." Desc="Hex-a-hop is a puzzle game in which a girl has to destroy green hexagons by stepping on them.  Hex-a-Hop files are already included and ready to go." porter="Cebion" locat="hex-a-hop.zip" runtype="rtr"
 
+Title="Hexen 2 ." Desc="Hexen II is a dark fantasy 1st-person shooter developed by Raven Software and published by id software.  Portal of Praevus features new levels, new enemies and a new playable character class, The Demoness.  You must copy your Hexen 2 pak0.pak and pak1.pak files into hexen2/data1 and your pak3.pak into hexen2/portals and make sure they're lowercase." porter="Slayer366" locat="Hexen2.zip"
+
 Title="Hocoslamfy ." Desc="You are a small bee and you must fly to avoid the bamboo shoots.  Hocoslamfy files are already included and ready to go." porter="Cebion" locat="hocoslamfy.zip" runtype="rtr"
 
 Title="Hurrican ." Desc="Turrican port by Thrimbor.  Just add the data and lang folders from here to the ports/hurrican folder or just launch Hurrican from the ports menu in Emulationstation and it will download the files and install them automatically." porter="romadu" locat="Hurrican.zip"


### PR DESCRIPTION
Hexen II is a dark fantasy 1st-person shooter developed by Raven Software and published by id software.  Portal of Praevus features new levels, new enemies and a new playable character class, The Demoness.  The Hexen II pak0.pak and pak1.pak data files are required for Hexen 2 and pak3.pak is required to play the Portal of Praevus expansion.
This should run on RG351P, RG351M, RG351MP, and RG503 running ArkOS or 351Elec/AmberElec (and likely other devices and OSes).
