### PR TITLE
Added Half-Life port.

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -74,6 +74,8 @@ Title="FreedroidRPG ." Desc="FreedroidRPG files are already included and ready t
 
 Title="Gigalomania ." Desc="Gigalomania is an open source 2D Real Time Strategy god game.  Gigalomania files are already included and ready to go." porter="Cebion" locat="gigalomania.zip" runtype="rtr"
 
+Title="Half-Life ." Desc="Half-Life is Valve's debut title which blends blends action and adventure with award-winning technology to create a frighteningly realistic world where players must think to survive. You need to have your own copy of the game. You need to copy the steam valve directory from your steam installation into ports/Half-Life/valve directory. You can also run Half-Life Blue Shift/Opposing Forces by copying the contents of the bshift/gearbox steam files into their respective ports/Half-Life/ directory." porter="kloptops" locat="Half-Life.zip"
+
 Title="Heart_of_Darkness ." Desc="Heart of Darkness using the hode reimplementation of the engine developed by Amazing Studio.  Just add your own Heart of Darkness game files to the ports/hode/gamedata folder." porter="Jetup" locat="Heart%20of%20Darkness.zip"
 
 Title="Hex-A-Hop ." Desc="Hex-a-hop is a puzzle game in which a girl has to destroy green hexagons by stepping on them.  Hex-a-Hop files are already included and ready to go." porter="Cebion" locat="hex-a-hop.zip" runtype="rtr"


### PR DESCRIPTION
# Half-Life, Half-Life: Blue Shift, Half-Life: Opposing Forces

To play **Half-Life** you need to copy over the contents of the `valve` directory from your steam install of [Half-Life](https://store.steampowered.com/app/70/HalfLife/) info `ports/Half-Life/valve`, on first run it will override the required files to run.

To play **Half-Life: Blue Shift** you need to have Half-Life installed, then copy over the contents of the `bshift` directory from your steam install of [Half-Life: Blue Shift](https://store.steampowered.com/app/130/HalfLife_Blue_Shift/) info `ports/Half-Life/bshift`, on first run it will override the required files to run, and create a `Half-Life Blue Shift.sh` in your ports directory.

To play **Half-Life: Opposing Forces** you need to have Half-Life installed, then copy over the contents of the `gearbox` directory from your steam install of [Half-Life: Opposing Forces](https://store.steampowered.com/app/50/HalfLife_Opposing_Force/) info `ports/Half-Life/gearbox`, on first run it will override the required files to run, and create a `Half-Life Opposing Fores.sh` in your ports directory.

Other than modifying the config files for each of the games, the games have just been built from the excellent [Xash3d](https://github.com/FWGS/xash3d-fwgs) engine and [hlsdk-portable](https://github.com/FWGS/hlsdk-portable) repos without any modification. Keybindings taken from the original [AnberPorts HalfLife](https://github.com/krishenriksen/Half-Life-rg351p). 

This currently has been tested to run on on RG353V and a RG351M on ArkOS/AmberElec/UnofficialOS.

It should run on a RG353P/M, RG351P/V/MP. and may also run on some of the other very similar handhelds and other OSes as well, but this has yet to be tried on those configurations.
