### PR TITLE
Added Rlvm port.

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -150,6 +150,8 @@ Title="Rigel_Engine ." Desc="A modern re-implementation of the classic DOS game 
 
 Title="Rise_Of_The_Triad ." Desc="An open source port of Rise of the Triad by icculus.  The demo files are already included." porter="romadu" locat="ROTT.zip" runtype="rtr"
 
+Title="Rlvm ." Desc="Rlvm is a Free Software reimplementation of the Key RealLive interpreter for Visual Novels. Notable games include CLANNAD, AIR, & KANON. Add your game files to the ports/rlvm/games/GAME_NAME directory, multiple games can be installed and you will get a choice of which game you want to play at launch. HD Releases do not currently work properly." porter="kloptops" locat="Rlvm.zip"
+
 Title="Rocks_N_Diamonds ." Desc="A Boulderdash type game by Holger Schemel with many unique features, such as the ability to play remade levels from Boulderdash, Emerald Mine and Supaplex and many more levels." porter="Christian_Haitian" locat="rocksndiamonds.zip" runtype="rtr"
 
 Title="RVGL ." Desc="An open source port of Re-Volt by the RV Team.  Necessary files will be downloaded and installed upon initial launch while connected to the internet." porter="romadu" locat="RVGL.zip"


### PR DESCRIPTION
# Real Live VM for Key Visual Novels

To play various Rlvm compatible Visual Novels you need to copy over the game files into `ports/rlvm/games` into their own directory. For example you would install the **CLANNAD** game files into `ports/rlvm/games/CLANNAD` directory. HD versions do not currently work correctly, nor does it work correctly on the RG351P/M devices. For better font compatibility add your own copy of `msgothic.ttc` into `ports/rlvm/fonts`.

[Rlvm](https://github.com/eglaysher/rlvm) is a RealLive interpreter to run Visual Novels by Key. Lots of small tweaks were required to get the engine to run. Fixes wee required for the font loading system, save locations, and fixes for the SDL_image code. This port also uses [gl4es](https://github.com/ptitSeb/gl4es), [sdl12-compat](https://github.com/libsdl-org/sdl12-compat), [DejaVu Fonts](https://dejavu-fonts.github.io), & [sazanami-gothic font](https://en.maisfontes.com/sazanami-gothic-regular.font).

This currently has been verified to run on on RG353V and a RG351V on ArkOS/AmberElec/UnofficialOS.
