### PR TITLE
[Bug Fix] Fixed ROMS2 Dir not being detected.

### DIFF
--- a/PortMaster/PortMaster.sh
+++ b/PortMaster/PortMaster.sh
@@ -218,7 +218,7 @@ PortInfoInstall() {
 local setwebsiteback="N"
 local unzipstatus
 
-  if [ ! -z "$(cat /etc/fstab | $GREP roms2 | tr -d '\0')" ]; then
+  if [ ! -z "$(cat /etc/fstab | $GREP "roms2" | tr -d '\0')" ]; then
     whichsd="roms2"
   elif [ -f "/storage/.config/.OS_ARCH" ] || [ "${OS_NAME}" == "JELOS" ] || [ "${OS_NAME}" == "UnofficialOS" ]; then
     whichsd="storage/roms"


### PR DESCRIPTION
I noticed this bug when I tried downloading Ports to my 353V with TF2 enabled and Portmaster would download them however it didn't download to my Portmaster folder in roms2.

Before, the roms2 was being passed as a file path (or command?) instead of a string.

This was causing Portmaster to always attempt to download in "roms" root directory, as the if statement would always be false. 

Before PR: We would get `roms2: not found` regardless if that is false. 

After the PR: The if statement will now correctly check for roms2. 

Now Portmaster will download to roms2 as expected if you have TF2 enabled. 

Tested on latest ArkOS on 353V 