### PR TITLE
Added OpenRCT2.

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -126,6 +126,8 @@ Title="OpenTTD ." Desc="An open source simulation game based upon Transport Tyco
 
 Title="OpenTyrian ." Desc="OpenTyrian is an open-source port of the DOS game Tyrian.  OpenTyrian 2.1 files are already included as they were made freeware sometime ago." porter="Christian_Haitian" locat="OpenTyrian.zip" runtype="rtr"
 
+Title="OpenRCD2 ." Desc="OpenRCT2 is Open source re-implementation of RollerCoaster Tycoon 2. Add your Roller Coaster Tycoon 2 game files to the ports/openrct2/RCT2 directory, and optionally add your Roller Coaster Tycoon 1 files to ports/openrct2/RCT1" porter="Kloptops" locat="OpenRCT2.zip"
+
 Title="OpenXcom_Extended ." Desc="OXCE is an open source engine for running XCOM:Ufo Defense and Terror From the Deep.  You will need to provide your own UFO Defense/TFTD game files.  Read the README-port.txt file for details." porter="nl255" locat="Openxcom.zip"
 
 Title_F="Otto_Matic ." Desc="This is Pangea Software’s Otto Matic. Take control of the robot Otto Matic and save earth from aliens from Planet X" porter="brooksytech" locat="ottomatic.zip" runtype="rtr"


### PR DESCRIPTION
# OpenRCT2 - Open Roller Coaster Tycoon 2

[OpenRCT2](https://github.com/OpenRCT2/OpenRCT2) is an open-source re-implementation of RollerCoaster Tycoon 2, a construction and management simulation video game that simulates amusement park management.

OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bought at either [Steam](https://store.steampowered.com/app/285330/) or [GOG.com](https://www.gog.com/game/rollercoaster_tycoon_2). If you have the original RollerCoaster Tycoon and its expansion packs, you can point OpenRCT2 to these in order to play the original scenarios.

Install your Roller Coaster Tycoon 2 game files into `{PORTS}/openrct2/RCT2`, **these files are required**, and optionally your Roller Coaster Tycoon 1 game files into `{PORTS}/openrct2/RCT1`.

For help getting the game files for [RCT2 on macOS & Linux](https://github.com/OpenRCT2/OpenRCT2/wiki/Installation-on-Linux-and-macOS), and for help getting game files for [RCT1](https://github.com/OpenRCT2/OpenRCT2/wiki/Loading-RCT1-scenarios-and-data).

This currently has been verified to run on on RG353P/V/M, RG351V/MP, RG552 on ArkOS/AmberElec/UnofficialOS. It can run on the RG351P/M devices but the screen resolution makes it not so great.

To get this port to run we have used [OpenRCT2](https://github.com/OpenRCT2/OpenRCT2), [DejaVU](https://dejavu-fonts.github.io), and [SDL_sim_cursor](https://github.com/kloptops/SDL_sim_cursor). A patch is provided [here](https://github.com/kloptops/Portmaster-misc/tree/main/OpenRCT2).
