### PR TITLE
Added Augustus.

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -16,6 +16,8 @@ Title="Alien_vs_Predator ." Desc="The three most ferocious species in the univer
 
 Title="AM2R ." Desc="Another Metroid 2 Remake.  An action-adventure game developed by Argentinian programmer Milton Guasti (also known as DoctorM64).  You'll need to provide your own am2r android apk into the ports/am2r/gamedata folder.  Make sure it is named am2r.apk.  The name is case sensitive." porter="Johnny on Flame" locat="AM2R.zip"
 
+Title="Augustus ." Desc="A reimplemntation of the Caeser 3 engine.  You will need the original files of the PC release copied to the ports/augustus/data folder." porter="Kloptops and Cebion" locat="Augustus.zip"
+
 Title="Bermuda_Syndrome ." Desc="A reimplemntation of the Berumuda Syndrome engine.  You will need the original files of the PC release or PC demo copied to the ports/bermuda/DATA folder." porter="jetup" locat="Bermuda_Syndrome.zip"
 
 Title_F="Billy_Frontier ." Desc="This is Pangea Software's Billy Frontier updated to run on modern operating systems. Use the touchscreen to navigate the UI and gameplay." porter="brooksytech" locat="billyfrontier.zip" runtype="rtr"


### PR DESCRIPTION
# Augustus - Open Source Caeser III

[Augustus](https://github.com/Keriew/augustus) is an open-source re-implementation of Caeser III a city-building simulation game developed by Impressions Games and published by Sierra On-Line in 1998. It is the third installment in the Caesar series and is set in ancient Rome.

Augustus  will not run without the original Caesar 3 files. You can buy a digital copy from GOG or Steam, or you can use an original CD-ROM version.

Install the game files into `ports/augustus/data`, here are some excellent instructions [from the Julius project](https://github.com/bvschaik/julius/wiki/Running-Julius) (which Augustus is a fork of). If installing from the CD's you'll need to get the [latest patches](https://github.com/bvschaik/julius/wiki/Patches).

This currently has been verified to run on on RG353P/V/M, RG351V/MP, RG552 on ArkOS/AmberElec/UnofficialOS.

To get this port to run we have used [Augustus](https://github.com/Keriew/augustus).
Controls were done by @Cebion (Thanks!).
A patch is provided [here](https://github.com/kloptops/Portmaster-misc/tree/main/Augustus) to enable the software cursor.