### PR TITLE
Added VCMI

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -254,6 +254,8 @@ Title="VanillaRA ." Desc="Vanilla Conquer is a fully portable version Command an
 
 Title="VanillaTD ." Desc="Vanilla Conquer is a fully portable version Command and Conquer Tiberium Dawn. The game comes with the demo files, read the README for detailed information on installing the full game." porter="kloptops and Snoopy" locat="VanillaTD.zip" runtype="rtr"
 
+Title="VCMI ." Desc="VCMI is a fully portable version of Heroes of Might and Magic III. Copy the GoG installer files to ports/vcmi and it will install the game files as required, see the README for more information." porter="kloptops" locat="VCMI.zip"
+
 Title="VVVVVV ." Desc="VVVVVV is a 2010 puzzle-platform game created by Terry Cavanagh.  The free Make and Play Edition data.zip file is already included.  You can also add your own purchased copy of the data.zip from your VVVVVV into the ports/VVVVVV folder if you prefer that version instead." porter="Christian_Haitian" locat="VVVVVV.zip" runtype="rtr"
 
 Title="Wetspot_2 ." Desc="A port of QuickBasic 4.5 game Wetspot 2 by Angelo Mottola.  Just download and play." porter="Cebion" locat="wetspot2.zip" runtype="rtr"


### PR DESCRIPTION
# VCMI - Heroes of Might and Magic III

[VCMI](https://github.com/vcmi/vcmi) is work-in-progress attempt to recreate engine for Heroes III, giving it new and extended possibilities.

VCMI will automatically copy and extract the required game files, you can either install from CD1 & CD2, GoG or an installed copy of the game. This requires about 2-3 gb of free space.

For the **gog version** copy `setup_heroes_of_might_and_magic_3_complete_4.0_(28740)-1.bin` and `setup_heroes_of_might_and_magic_3_complete_4.0_(28740).exe` into `ports/vcmi`.

For the **cd version** copy the contents of **cd1** into `ports/vcmi/cd1` and **cd2** into `ports/vcmi/cd2`.

For the **installed version** copy installed game files into `ports/vcmi/install`.

So far I have only reliably tested the GoG version, so your mileage may vary.

This currently has been verified to run on on RG353P/V/M, RG351V/MP, RG552 on ArkOS/AmberElec/UnofficialOS.

To get this port to run we have used:
- [VCMI](https://github.com/vcmi/vcmi)
- A patch is provided [here](https://github.com/kloptops/Portmaster-misc/tree/main/VCMI) to implement a few modifications required to run.
