### PR TITLE
Add Titan Tactics / Fix typo in TinyCrate

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -253,7 +253,9 @@ Title="Tile_World ." Desc="Tile World is a source port clone of Chip's Challenge
 
 Title="Timespinner ." Desc="Travel back in time to change fate itself, in this beautifully crafted story-driven adventure, inspired by classic 90s action-platformers.  You must have a copy of Timespinner for Linux copied to the ports/timespinner/gamedata folder." porter="Johnny on Flame" locat="Timespinner.zip" mono="y"
 
-Title="Tiny_Crate ." Desc="Tiny Crate is a cute little precision platformer with puzzle elements! Lift and toss crates to traverse over spike pits and reach higher ground! Push yourself and make tight jumps! You got this!." porter="Cebion" locat="tiny-crate.zip" runtype="rtr"
+Title="Tiny_Crate ." Desc="Tiny Crate is a cute little precision platformer with puzzle elements! Lift and toss crates to traverse over spike pits and reach higher ground! Push yourself and make tight jumps! You got this!" porter="Cebion" locat="tiny-crate.zip" runtype="rtr"
+
+Title="Titan_Tactics ." Desc="A follow up to Pocket Tactics, Titan Tactics is inspired by the awesome tactic games of the 90s. Fight with your allies and uncover the mysteries of the kingdoms of Tyrmyr and Skathi!" porter="Cebion" locat="titan_tactics.zip" runtype="rtr"
 
 Title="Tomb_Raider_1 ." Desc="An open source port of Tomb Raider 1 using OpenLara engine by xProger.  Just add your steam or gog Tomb Raider 1 files to the ports/tombraider1 folder." porter="Jetup" locat="Tomb%20Raider%201.zip"
 


### PR DESCRIPTION
Removed the . in Tiny Crate and added a new Port for Titan Tactics

Titan Tactics
Instructions: Titan Tactics files are already included and ready to go. Just start Titan Tactics from Ports in the Emulationstation menu.
Notes: Thanks to Team Potato (https://gitlab.com/team-potato/titan_tactics)  for creating this game and making available for free and efornara for creating the FRT platform. Also thanks to Cebion for the packaging for portmaster.

Tested on AmberELEC, ArkOS, uOS