### PR TITLE
Add Pekka Kana 2

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -171,6 +171,8 @@ Title="Oddworld:_Abes_Oddysee_Exoddus ." Desc="It is a platformer with puzzle-so
 
 Title="Owlboy ." Desc="A story-driven platform adventure game, where you can fly and explore a brand new world in the clouds.  Text is not readable on devices with screens less than 5 inches.  You must have a copy of Owlboy for Linux copied to the ports/owlboy/gamedata folder." porter="Johnny on Flame" locat="Owlboy.zip" mono="y"
 
+Title="Pekka_Kana_2 ." Desc="Pekka Kana 2 (Pekka the Rooster 2) is a jump 'n run game made in the spirit of old classic platformers such as Super Mario, Sonic the Hedgehog, Jazz Jackrabbit, Super Frog and so on. Pekka Kana 2 files are already included and ready to go." porter="Cebion" locat="pekka-kana-2.zip" runtype="rtr"
+
 Title="Powder ." Desc="A roguelike is a dungeon crawler where no two games are the same. The maps are different, the items are different, there are no guaranteed win paths.  Powder files are already included and ready to go." porter="Cebion" locat="powder.zip" runtype="rtr"
 
 Title="Prehistorik_2 ." Desc="A caveman-era platform game using the Blues Brothers game engine developed by Titus Interactive.  Includes the demo files.  You can add your own full game Dos files to the ports/prehistorik2/gamedata folder." porter="Jetup" locat="Prehistorik%202.zip" runtype="rtr"


### PR DESCRIPTION
New Port for Pekka Kana 2

Pekka Kana 2
Instructions: Pekka Kana 2 files are already included and ready to go. Just start Pekka Kana 2 from Ports in the Emulationstation menu.

Notes: Thanks to Janne Kivilahti, Samuli Tuomola, Danilo Lemos for creating this game, porting it to SDL and finally to SDL2 and making it available for free. Also thanks to Cebion for the packaging for portmaster.

Tested on AmberELEC, ArkOS, uOS