### PR TITLE
Add Hijinx Port

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -117,6 +117,8 @@ Title="Hex-A-Hop ." Desc="Hex-a-hop is a puzzle game in which a girl has to dest
 
 Title="Hexen_2 ." Desc="Hexen II is a dark fantasy 1st-person shooter developed by Raven Software and published by id software.  Portal of Praevus features new levels, new enemies and a new playable character class, The Demoness.  You must copy your Hexen 2 pak0.pak and pak1.pak files into hexen2/data1 and your pak3.pak into hexen2/portals and make sure they're lowercase." porter="Slayer366" locat="Hexen2.zip"
 
+Title="Hijinx ." Desc="A game about platforming, curses, and turtles. Files are already included and ready to go." porter="Cebion" locat="hijinx.zip" runtype="rtr"
+
 Title="Hocoslamfy ." Desc="You are a small bee and you must fly to avoid the bamboo shoots.  Hocoslamfy files are already included and ready to go." porter="Cebion" locat="hocoslamfy.zip" runtype="rtr"
 
 Title="Hurrican ." Desc="Turrican port by Thrimbor.  Just add the data and lang folders from here to the ports/hurrican folder or just launch Hurrican from the ports menu in Emulationstation and it will download the files and install them automatically." porter="romadu" locat="Hurrican.zip"


### PR DESCRIPTION
New Port Hijinx

Hijinx
Instructions: Hijinx files are already included and ready to go. Just start the game from Ports in the Emulationstation menu.

Notes: Thanks to John Gabriel (https://bitbucket.org/JohnGabrielUK/hijinx/)  for creating this game and making it available for free. Also thanks to Cebion for the packaging for portmaster.

Tested on AmberELEC, ArkOS, uOS