### PR TITLE
Add ZGloom

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -296,3 +296,7 @@ Title="Wordle_SDL ." Desc="Wordle SDL is a port of a simple clone of Wordle made
 Title="World_War_II_GI ." Desc="World War 2 GI using the rednukem build open source port by Alexey Khokholov.  You'll need to add your own full version WW2GI.GRP and WW2DI.RTS and .CON files and optionally CD audio tracks as OGG file in the format trackXX.ogg (where XX is the track number) to the ports/rednukem-WWII/gamedata folder." porter="romadu" locat="World%20War%20II%20GI.zip" genres="fps"
 
 Title="Worship_Vector ." Desc="Worship Vector is a Tower Defense type game. The game is based upon a unique map, which extends automatically.  Just download and play." porter="Cebion" locat="worship_vector.zip" runtype="rtr" genres="puzzle"
+
+Title="ZGloom ." Desc="ZGloom is a re-implementation of Amiga FPS Gloom, including support for Gloom 3, Gloom Deluxe and Zombie Massacre." porter="Bamboozler" locat="ZGloom.zip" runtype="rtr" genres="fps"
+
+


### PR DESCRIPTION
# Description

ZGloom is a re-implementation of Amiga FPS Gloom, including support for Gloom 3, Gloom Deluxe and Zombie Massacre.

This port includes Gloom, Gloom 3 as is from developer and Gloom Deluxe 1 level demo

Gloom was released as is from developers - https://github.com/earok/GloomAmiga
Gloom 3 was released by developers - http://aminet.net/package/game/shoot/UltimateGloomISO
Zombie Massacre was released by developers - http://aminet.net/package/game/shoot/ZombieMassacreISO
Gloom Deluxe is a 1 level demo - http://aminet.net/package.php?package=game/demo/Gloom_Deluxe.dms


**Change Type**

- [x] New Port


Details:

Developer: Swizpig (https://github.com/Swizpig)

URL: https://github.com/Swizpig/ZGloom

Cheat system backported from https://github.com/JetStreamSham/ZGloom-vita
Corrected scaling
Added mapping for dpad in game
Added ability to pass game path as argument




# How Has This Been Tested?

List the device and or os combinations that were used to test.

ArkOS,uOS, AmberELEC
RG552
RG351v
RG351MP
RG353M



# Checklist

**If this is a new port, pelase make sure it has the following:**

If you are not sure, check your port [here](https://kloptops.github.io/harbourmaster/port.html).

- [x] port.json
