### PR TITLE
Add Hawkthorne

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -44,7 +44,6 @@ Title="Blues_Brothers ." Desc="A rewrite of the Blues Brothers game engine devel
 
 Title="Blues_Brothers:_Jukebox_Adventure ." Desc="A rewrite of the Blues Brothers game engine developed by Titus Interactive.  Includes the demo files.  You can add your own full game Dos files to the ports/bbda/gamedata folder." porter="Jetup" locat="BBJA.zip" runtype="rtr" genres="platformer"
 
-
 Title_F="Bugdom ." Desc="This is Pangea Software's Bugdom updated to run on modern operating systems. Use the touchscreen to navigate the UI." porter="brooksytech" locat="Bugdom.zip" runtype="rtr" genres="action,adventure"
 
 Title="Cannonball ." Desc="This is the libretro port of the OutRun game engine recreation written by Chris White in 2014.  Add the OutRun Revision B ROMs into /ports/cannonball/gamedata folder. " porter="Christian_Haitian" locat="Cannonball.zip" genres="racing"
@@ -112,6 +111,8 @@ Title="GemRB ." Desc="GemRB (Game Engine Made with preRendered Background) is a 
 Title="Gigalomania ." Desc="Gigalomania is an open source 2D Real Time Strategy god game.  Gigalomania files are already included and ready to go." porter="Cebion" locat="gigalomania.zip" runtype="rtr" genres="strategy"
 
 Title="Half-Life ." Desc="Half-Life is Valve's debut title which blends blends action and adventure with award-winning technology to create a frighteningly realistic world where players must think to survive. You need to have your own copy of the game. You need to copy the steam valve directory from your steam installation into ports/Half-Life/valve directory. You can also run Half-Life Blue Shift/Opposing Forces by copying the contents of the bshift/gearbox steam files into their respective ports/Half-Life/ directory." porter="kloptops" locat="Half-Life.zip" genres="fps,action"
+
+Title="Hawkthorne ." Desc="This 2d platformer is based on Community's Digital Estate Planning episode." porter="Cebion" locat="hawkthorne.zip" runtype="rtr" genres="platformer,rpg"
 
 Title="Heart_of_Darkness ." Desc="Heart of Darkness using the hode reimplementation of the engine developed by Amazing Studio.  Just add your own Heart of Darkness game files to the ports/hode/gamedata folder." porter="Jetup" locat="Heart%20of%20Darkness.zip" genres="action,platformer"
 
@@ -296,7 +297,3 @@ Title="Wordle_SDL ." Desc="Wordle SDL is a port of a simple clone of Wordle made
 Title="World_War_II_GI ." Desc="World War 2 GI using the rednukem build open source port by Alexey Khokholov.  You'll need to add your own full version WW2GI.GRP and WW2DI.RTS and .CON files and optionally CD audio tracks as OGG file in the format trackXX.ogg (where XX is the track number) to the ports/rednukem-WWII/gamedata folder." porter="romadu" locat="World%20War%20II%20GI.zip" genres="fps"
 
 Title="Worship_Vector ." Desc="Worship Vector is a Tower Defense type game. The game is based upon a unique map, which extends automatically.  Just download and play." porter="Cebion" locat="worship_vector.zip" runtype="rtr" genres="puzzle"
-
-Title="ZGloom ." Desc="ZGloom is a re-implementation of Amiga FPS Gloom, including support for Gloom 3, Gloom Deluxe and Zombie Massacre." porter="Bamboozler" locat="ZGloom.zip" runtype="rtr" genres="fps"
-
-


### PR DESCRIPTION
New Port for Journey to the Center of Hawkthorne

Journey to the Center of Hawkthorne
Instructions: Game files are already included and ready to go. Just start the game from Ports in the Emulationstation menu.

Notes: Thanks to the Project Hawkthorne Team  (https://github.com/hawkthorne/hawkthorne-journey) for creating this game and making it available for free. Also thanks to Cebion for the packaging for portmaster.

Tested on: AmberELEC RG552, 351V, 351P, uOS, ArkOS, Jelos 