### PR TITLE
Add Plaque Attack Remake

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -204,6 +204,8 @@ Title="Pigeon_Ascent ." Desc="*Optimized for 4:3 640x480 and 5:3 1920x1152*. Tak
 
 Title="Planet_Waves ." Desc="*Works in 640x480. Optimized for 4:3 or higher aspect ratio. Could scale weirdly on gameboy like aspect ratio.* An arcade tower defense about protecting a small planet made for the gotm.io jam #3 by Escada Games. Planet Waves files are already included and ready to go." porter="Tekkenfede" locat="planetWaves.zip" runtype="rtr" genres="strategy"
 
+Title="Plaque_Attack_Remake ." Desc="*Optimized for 4:3 and 16:9(or similar ex. rg552). Could scale weirdly on gameboy like aspect ratio.* Atari 2600's Plaque Attack game remake made for Highjam #1 by Escada Games. Plaque attack Remake files are already included and ready to go. To Force a particular version rename the desired one in the installation folder as PlaqueAttackRemake.zip and delete the other one, then boot." porter="Tekkenfede" locat="PlaqueAttackRemake.zip" runtype="rtr" genres="action,other"
+
 Title="Powder ." Desc="A roguelike is a dungeon crawler where no two games are the same. The maps are different, the items are different, there are no guaranteed win paths.  Powder files are already included and ready to go." porter="Cebion" locat="powder.zip" runtype="rtr" genres="rpg"
 
 Title="Prehistorik_2 ." Desc="A caveman-era platform game using the Blues Brothers game engine developed by Titus Interactive.  Includes the demo files.  You can add your own full game Dos files to the ports/prehistorik2/gamedata folder." porter="Jetup" locat="Prehistorik%202.zip" runtype="rtr" genres="platformer"


### PR DESCRIPTION
New Port for Plaque Attack Remake

URL: https://github.com/Keyband/dentaldefense

Plaque Attack Remake

Instructions: To run the game start PlaqueAttackRemake.sh from your ports folder. To Force a particular version rename the desired one in the installation folder as PlaqueAttackRemake.zip and delete the other one, then boot.

Notes: A big thanks to Escada Games for creating the game and sharing the source code. And, of course, a huge thanks to the Portmaster Team for testing!

Tested on Rg353,RG351v and rg552 on Amberelec, Arkos and Jelos