### PR TITLE
Update ports.md

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -4,7 +4,7 @@ Title="Abe's_Amazing_Adventure ." Desc="A scrolling, platform-jumping, key-colle
 
 Title="Abu_Simbel_Profanation_Deluxe ." Desc="An open-source, freeware remake of the Spanish platform game from 1985 replaces the graphics and sounds with new enhanced assets, while maintaining the same unforgiving gameplay of the original.  Just download and play." porter="Cebion" locat="profadeluxe.zip" runtype="rtr" genres="adventure,platformer"
 
-Title="Abuse ." Desc="A fork of the original Abuse SDL port from http://abuse.zoy.org/.  An intense 2D shooter.  Plays best on dual analog stick devices.  Just download and play." porter="romadu" locat="Abuse.zip" genres="action,shooter"
+Title="Abuse ." Desc="A fork of the original Abuse SDL port from http://abuse.zoy.org/.  An intense 2D shooter.  Plays best on dual analog stick devices.  Just download and play." porter="romadu" locat="Abuse.zip" runtype="rtr" genres="action,shooter"
 
 Title="Aleph-One_Marathon_1 ." Desc="An open source version of Bungie's Marathon 1 first person shooter. All files have been included." porter="romadu" locat="alephone-marathon.zip" runtype="rtr" genres="fps"
 


### PR DESCRIPTION
Added the "runtype" value for the Abuse port. It wasn't specified before and it now set as "rtr".

Modified port definitions

URL: N/A

Abuse

Instructions: N/A
Notes: Thank you to romadu for the wonderful port and thank you to the awesome portmaster contributors.

Tested on RG353VS