### PR TITLE
TileWorld now HandHeld edition.

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -300,7 +300,7 @@ Title="Tamatool ." Desc="Tamatool is a Tamagotchi P1 emulator. Tamatool requires
 
 Title="Thermomorph ." Desc="An Alien-inspired survive-the-night horror game, created in Love2D." porter="Cebion" locat="thermomorph.zip" runtype="rtr" genres="simulation,other"
 
-Title="Tile_World ." Desc="Tile World is a source port clone of Chip's Challenge.  To play the original Chip's Challenge levels, copy your "chips.dat" into 'ports/tileworld/data' and make sure it's lowercase.  The almost complete SDL2 conversion used: github.com/rangeli/tileworld" porter="Slayer366" locat="TileWorld.zip" runtype="rtr" genres="puzzle"
+Title="Tile_World ." Desc="Tile World is a source port clone of Chip's Challenge.  To play the original Chip's Challenge levels, copy 'chips.dat' into 'ports/tileworld/data' and make sure it's lowercase.  Handheld edition based on: https://github.com/senquack/tileworld-for-handhelds" porter="Slayer366" locat="TileWorld.zip" runtype="rtr" genres="puzzle"
 
 Title="Timespinner ." Desc="Travel back in time to change fate itself, in this beautifully crafted story-driven adventure, inspired by classic 90s action-platformers.  You must have a copy of Timespinner for Linux copied to the ports/timespinner/gamedata folder." porter="Johnny on Flame" locat="Timespinner.zip" mono="y" genres="action,adventure"
 


### PR DESCRIPTION
New (Updated) Port for Tile World based on the handheld version by senquack.

URL: Handheld version by senquack: https://github.com/senquack/tileworld-for-handhelds
Tile World written originally by Brian Raiter: https://www.muppetlabs.com/~breadbox/software/tworld/

Tile World

Instructions: To play the original Chip's Challenge levels, copy 'chips.dat' into 'ports/tileworld/data' and make sure it's lowercase.

Notes: Modified source code and graphics to 640x480 (was 320x240 for GP2X & GCW0), fixed save system bug and sprite drawing by AAK (Slayer366).  Custom "Tilebyte" game fonts by JRK (Budah).

Tested on ArkOS, AmberElec, JelOS, RG351P, RG353P (should also work on other platform and OS combinations).