### PR TITLE
Add Wizznic!

### DIFF
--- a/ports.md
+++ b/ports.md
@@ -328,6 +328,8 @@ Title="VVVVVV ." Desc="VVVVVV is a 2010 puzzle-platform game created by Terry Ca
 
 Title="Wetspot_2 ." Desc="A port of QuickBasic 4.5 game Wetspot 2 by Angelo Mottola.  Just download and play." porter="Cebion" locat="wetspot2.zip" runtype="rtr" genres="action"
 
+Title="Wizznic! ." Desc="Wizznic! is an open-source, freeware remake of Puzznic, recreating the original arcade levels, the NES ones and including fan-made puzzle packs with new custom levels." porter="Bamboozler" locat="Wizznic.zip" runtype="rtr" genres="puzzle"
+
 Title="Wordle_SDL ." Desc="Wordle SDL is a port of a simple clone of Wordle made with SDL." porter="Bamboozler" locat="WordleSDL.zip" runtype="rtr" genres="puzzle"
 
 Title="World_War_II_GI ." Desc="World War 2 GI using the rednukem build open source port by Alexey Khokholov.  You'll need to add your own full version WW2GI.GRP and WW2DI.RTS and .CON files and optionally CD audio tracks as OGG file in the format trackXX.ogg (where XX is the track number) to the ports/rednukem-WWII/gamedata folder." porter="romadu" locat="World%20War%20II%20GI.zip" genres="fps"


### PR DESCRIPTION
New Port for Wizznic!

URL: https://github.com/DusteDdk/Wizznic

Wizznic!

Instructions: All files are included and game is ready to play.

Notes:  Thanks to DusteDdk for making this game, Bamboozler for packaging to Portmaster and the Portmaster testers for testing.

Tested on AmberELEC, ArkOS and Jelos