### PR TITLE
add markdown forlder

### DIFF
--- a/markdown/cceleste.md
+++ b/markdown/cceleste.md
@@ -1,0 +1,25 @@
+
+**Controls**
+
+Start/Select = Pause
+
+Start+Select = Exit
+
+Dpad  and Left stick = left/right and look up/down
+Right Stick = left/right
+
+A = Jump
+B = Dash
+Y = Hold to reset
+X = Toggle screenshake
+
+l1/l2 = Load state
+r1/r2 - Save state
+
+Start + Select = Exit
+
+**Developer Notes:**
+
+Build instructions:
+
+Standard makefile

--- a/markdown/devilutionx.md
+++ b/markdown/devilutionx.md
@@ -1,0 +1,32 @@
+
+**Controls**
+
+DevilutionX supports most gamepad controls.
+
+Default controller mappings (A/B/X/Y as in Nintendo layout, so the rightmost button is attack; A ○, B ×, X △, Y □):
+
+-   Left analog or D-Pad: move hero
+-   A: attack nearby enemies, talk to townspeople and merchants, pickup/place items in the inventory, OK while in main menu
+-   B: select spell, back while in menus
+-   X: pickup items, open nearby chests and doors, use item in the inventory
+-   Y: cast spell, delete character while in main menu
+-   L1: use health item from belt
+-   R1: use mana potion from belt
+-   L2: character sheet (alt: Start + L1 or ←)
+-   R2: inventory (alt: Start + L2 or →)
+-   Left analog click: toggle automap (alt: Start + ↓)
+-   Start + Select: game menu (alt: Start + ↑)
+-   Select + A/B/X/Y: Spell hotkeys
+-   Right analog: move automap or simulate mouse
+-   Right analog click: left mouse click (alt: Select + L1)
+-   Select + Right analog click: right mouse click (alt: Select + R1)
+-   Select + L2: quest log (alt: Start + Y)
+-   Select + R2: spell book (alt: Start + B)
+
+**Developer Notes**
+
+Build instructions:
+
+git clone --recursive https://github.com/diasurgical/devilutionX.git 
+git checkout tags/{version}
+cmake -S. -Bbuild -DCMAKE_BUILD_TYPE="Release" -DDISABLE_ZERO_TIER=ON -DBUILD_TESTING=OFF -DBUILD_ASSETS_MPQ=OFF -DDEBUG=OFF -DPREFILL_PLAYER_NAME=ON

--- a/markdown/f1race.md
+++ b/markdown/f1race.md
@@ -1,0 +1,17 @@
+
+**Controls**
+
+Select = Esc/Exit
+Start + Select = Exit
+
+Dpad and left stick = movement
+
+A = Jump/Fly
+X = Switch MIDI
+Y = Toggle mute
+
+**Developer Notes:**
+
+Build instructions:
+
+make build-linux

--- a/markdown/nonny.md
+++ b/markdown/nonny.md
@@ -1,0 +1,54 @@
+
+
+**Features**
+
+-   Can play both standard and multicolor nonograms
+    -   Tracks completion status for all puzzles
+    -   Tracks time spent on solving each puzzle and records best completion times
+    -   Will save your progress on unfinished puzzles
+    -   Optional hint system shows you which lines can be further solved
+    -   No explicit limits on puzzle size or complexity
+    -   Information panel shows details about the current puzzle and shows a snapshot of the puzzle grid
+-   Can create both standard and multicolor nonograms
+    -   Various drawing tools are available: draw lines, rectangles, and ellipses, or fill regions with a particular color
+    -   Allows you to save title, author, and copyright information for each puzzle you create
+-   Undo and redo commands can be used while solving or editing puzzles
+-   Built-in solver and analysis tool
+    -   Will solve most simple puzzles very quickly
+    -   Can solve puzzles which require guessing or multi-line reasoning
+    -   Can determine whether a puzzle has a unique solution
+    -   Can determine whether a puzzle is solvable one line at a time
+    -   Can find and display multiple solutions for a puzzle
+-   File selector displays puzzle information and allows you to load and save puzzles anywhere and in various file formats
+    -   Supports the  [.non format](http://www.lancaster.ac.uk/~simpsons/nonogram/fmt2)  used in Steven Simpson's solver, extended with multicolor support
+    -   Supports the .g and .mk formats used in  [Mirek Olšák and Petr Olšák's solver](http://www.olsak.net/grid.html#English)
+    -   Supports the .nin format used by  [Jakub Wilk's solver](https://jwilk.net/software/nonogram)
+
+
+**Controls**
+
+File Menu
+
+Dpad nd and Left stick up/down = up and down
+Dpad and Left stick left/right = move through navigation breadcrums
+B = up one directory
+Y = Home directory
+A = Select file
+X = Open saved
+
+Puzzle Screen
+
+Dpad and left stick = move selector
+A = Select/Unselect
+B = Mark X
+Y = Toggle hints
+X = Analyze and solve
+L1/R1 = Zoom out/in
+L2/R2 = cycle colors
+Right stick = Move puzzle
+
+**Developer Notes:**
+
+Build instructions:
+
+Standard cmake

--- a/markdown/znax.md
+++ b/markdown/znax.md
@@ -1,0 +1,18 @@
+
+**Controls**
+
+Start = Enter
+Select = Back/Esc
+Start + Select = Exit
+
+Dpad and left stick = move left/right
+
+A = Select
+Y = Cycle theme
+
+**Developer Notes:**
+
+Build instructions:
+
+Standard makefile
+


### PR DESCRIPTION
add markdown folder that will be referenced in the "additional details" section of the details page for the port wiki