### PR TITLE
Fix and sync wiki entries between old github wiki with the new website

### DIFF
--- a/markdown/alephone-marathoninfinity.md
+++ b/markdown/alephone-marathoninfinity.md
@@ -1,6 +1,13 @@
 ## Notes
-<br/>
 
-Thanks to the [Aleph-One-Marathon Team](https://github.com/Aleph-One-Marathon/alephone) for creating this opensource engine.  Also thanks to romadu for the porting work for portmaster.
-<br/>
+Notes: Thanks to the [Aleph-One-Marathon Team](https://github.com/Aleph-One-Marathon/alephone) for creating this opensource engine. 
 
+
+## Compile
+
+```shell
+Download Sourcetarball from https://alephone.lhowon.org/download/source.php
+./configure --without-speex --without-curl --without-zzip --without-png --without-miniupnpc --without-ffmpeg --without-alsa
+make
+strip Source_Files/alephone
+```

--- a/markdown/am2r.md
+++ b/markdown/am2r.md
@@ -1,7 +1,8 @@
 ## Notes
-<br/>
 
-Thanks to JohnnyonFlame for the [droidports](https://github.com/JohnnyonFlame/droidports) loader that makes this possible.
-You can donate towards JohnnyonFlame's work [here](https://ko-fi.com/johnnyonflame)
-<br/>
+You'll need to source your own am2r android apk and place it into the ports/am2r/gamedata folder. Make sure it is named am2r.apk. If need be, just rename the am2r apk you source to am2r.apk. The name is case sensitive!
+
+Thanks to JohnnyonFlame for the[ droidports](https://github.com/JohnnyonFlame/droidports) loader that makes this possible.
+
+
 

--- a/markdown/augustus.md
+++ b/markdown/augustus.md
@@ -1,6 +1,8 @@
 ## Notes
-<br/>
 
-Thanks to [Keriew](https://github.com/Keriew/augustus) for this modified version of the open source julius port from [Bianca van Schaik](https://github.com/bvschaik/julius) and other contributors. Also thanks to [Kloptops](https://github.com/kloptops/Portmaster-misc/tree/main/Augustus) for the packaging for portmaster and Cebion for the controls work.
-<br/>
+ You can buy a digital copy from GOG or Steam, or you can use an original CD-ROM version. Install the game files into ports/augustus/data, here are some excellent instructions from the[ Julius project](https://github.com/bvschaik/julius/wiki/Running-Julius) (which Augustus is a fork of). If installing from the CD's you'll need to get the [latest patches](https://github.com/bvschaik/julius/wiki/Patches).
+ 
+ 
+Thanks to [Keriew](https://github.com/Keriew/augustus) for this modified version of the open source julius port from [Bianca van Schaik](hhttps://github.com/bvschaik/julius) and other contributors. Also thanks to Kloptops for the packaging for portmaster and Cebion for the controls work.
+
 

--- a/markdown/billyfrontier.md
+++ b/markdown/billyfrontier.md
@@ -1,6 +1,7 @@
 ## Notes
-<br/>
+
+Use the touchscreen to navigate the U and some gameplay. Currently only runs on the RG552 with Jelos installed.
 
 Thanks to Pangea Software for creating the game and publicly releasing the game files. Thanks to [Jorio](https://github.com/jorio/BillyFrontier) for porting the game engine to various platforms. Also thanks to brooksytech for the porting work for portmaster.
-<br/>
+
 

--- a/markdown/bugdom.md
+++ b/markdown/bugdom.md
@@ -1,6 +1,7 @@
 ## Notes
-<br/>
 
-Thanks to Pangea Software for creating the game and publicly releasing the game files. Thanks to [Jorio](https://github.com/jorio/Bugdom) for porting the game engine to various platforms.  Also thanks to brooksytech for the porting work for portmaster.
-<br/>
+Use the touchscreen to navigate the UI. Currently only runs on the RG552 with Jelos installed.
+
+Thanks to Pangea Software for creating the game and publicly releasing the game files. Thanks to [Jorio](https://github.com/jorio/Bugdom) for porting the game engine to various platforms.
+
 

--- a/markdown/burst.md
+++ b/markdown/burst.md
@@ -1,6 +1,16 @@
 ## Notes
-<br/>
 
-Thanks to [Edgar Mendoza](https://edgarmendoza.itch.io/) for creating this game and for permission to bundle the game files.  Also thanks to tabreturn for the porting work for portmaster.
-<br/>
+Thanks to [Edgar Mendoza](https://edgarmendoza.itch.io/) for creating this game and for permission to bundle the game files.  
+
+
+
+## Controls
+
+| Button | Action |
+|--|--| 
+|DPAD|Movement|
+|A / B|Dash|
+|R1 |Restart|
+|Start|Pause|
+
 

--- a/markdown/cannonball.md
+++ b/markdown/cannonball.md
@@ -1,6 +1,10 @@
 ## Notes
-<br/>
+
+For exact naming of roms, view this [link](https://github.com/djyt/cannonball/blob/master/roms/roms.txt)
 
 Thanks to [djyt](https://github.com/djyt/cannonball) for creating the engine for this OutRun arcade game and thanks to [Libretro](https://github.com/libretro/cannonball) for adding this as a retroarch core.
-<br/>
+
+
+
+
 

--- a/markdown/chasm.md
+++ b/markdown/chasm.md
@@ -1,9 +1,26 @@
 ## Notes
-<br/>
+
+* Download the Linux build of Chasm from your favorite platform, such as GOG, Steam or Humble:
+* [Steam](https://store.steampowered.com/app/312200/Chasm/) (windows, etc):
+				* Copy the following URL on your browser: steam://open/console
+				* Run the following command on the console: download_depot 312200 312202
+				* Find the assets on the path reported by the console when the download is finished.
+* [GOG](https://www.gog.com/game/chasm):
+				* Download the Linux build of the game on the website.
+				* Rename the .sh file (e.g. chasm_1_084_61001.sh) to .gzip (e.g. chasm_1_084_61001.gzip)
+				* Extract the file with your favorite utility (such as 7zip, unzip, etc.).
+				* Find the assets on chasm_1_084_61001\data\noarch\game\
+* [Humble](https://www.humblebundle.com/store/chasm):
+				* Pending (I don't have a humble copy 🤷)
+* Copy all of the Linux build files, such as Chasm.exe and all of the accompanying files to chasm/gamedata
+* Enjoy.
+
+
+
 
 Thanks for the the [FNA Project](https://github.com/FNA-XNA/FNA) for the amazing cross-platform, portable implementation of XNA.
 Thanks to the [Bit Kid](https://bitkidgames.com/) folks for the amazing game and patience.
-Thanks to JohnnyonFlame for the [FNA patches](https://github.com/JohnnyonFlame/FNAPatches) that makes this possible and the packaging for portmaster.
-You can donate towards JohnnyonFlame's work [here](https://ko-fi.com/johnnyonflame)
-<br/>
+Thanks to JohnnyonFlame for the [FNA patches](https://github.com/JohnnyonFlame/FNAPatches) that makes this possible
+
+
 

--- a/markdown/corsixth.md
+++ b/markdown/corsixth.md
@@ -1,6 +1,9 @@
 ## Notes
-<br/>
 
-Thanks to [CorsixTH](https://github.com/CorsixTH/CorsixTH) team for creating this clone of Theme Hospital.  Also thanks to jetup and romadu for the porting work for portmaster.
-<br/>
+If you plan to use a full GOG version of the assets,there's a file HOSP/DATAM/DEMO.DAT that needs to be deleted when full game files are added or the port will be confused about whether what version is played, and erroneously checks the GOG files as invalid file sizes. See this[ issue](https://github.com/CorsixTH/CorsixTH/issues/2092) for more information. 
+
+Thanks to [CorsixTH](https://github.com/CorsixTH/CorsixTH) team for creating this clone of Theme Hospital.  
+
+
+
 

--- a/markdown/cosmo-engine.md
+++ b/markdown/cosmo-engine.md
@@ -1,6 +1,9 @@
 ## Notes
-<br/>
+
+You can add episode 2 & 3 (STN,VOL, and CFG files) to the ports/cosmo-engine/data folder. 
 
 Thanks to [Eric Fry](https://github.com/yuv422/cosmo-engine) and other contributors for this open source engine.  Also thanks to Bamboozler for the porting work for portmaster.
-<br/>
+
+
+
 

--- a/markdown/cromagrally.md
+++ b/markdown/cromagrally.md
@@ -1,6 +1,9 @@
 ## Notes
-<br/>
 
-Thanks to Pangea Software for creating the game and publicly releasing the game files. Thanks to [Jorio](https://github.com/jorio/CroMagRally) for porting the game engine to various platforms.  Also thanks to brooksytech for the porting work for portmaster.
-<br/>
+Currently only runs on the RG552 with Jelos installed.
+
+
+Thanks to Pangea Software for creating the game and publicly releasing the game files. Thanks to [Jorio](https://github.com/jorio/CroMagRally) for porting the game engine to various platforms. 
+
+
 

--- a/markdown/devilutionx.md
+++ b/markdown/devilutionx.md
@@ -1,6 +1,18 @@
 ## Notes
-<br/>
+
+Copy diabdat.mpq from your CD or GoG installation (or extract it from the GoG installer) into /roms/ports/devilution folder. 
+
+Do not delete the gamecontrollerdb.txt file in the /roms/ports/devilution folder or there will be no controller support in the game! For controls, see here
+
+**Important Note: ** It’s been reported that you must make sure you use the GOG version of diabdat.mpq with the newest patch_rt.mpq or you may experience a freeze of the game around level 20.
+
+If you experience issues after a version upgrade, backup your save file and uninstall/reinstall the port.
+
+If you make a config change that crashes the game, you can delete the ini file to get the game back to a good state
 
 Thanks to the [diasurgical](https://github.com/diasurgical/devilutionX) team for the source port that makes this possible.
-<br/>
+
+
+
+
 

--- a/markdown/exult.md
+++ b/markdown/exult.md
@@ -1,6 +1,12 @@
 ## Notes
-<br/>
 
-Thanks to the [Exult Team](https://github.com/exult/exult) for the Exult engine that makes this possible.  Also thanks to nl255 for the porting work for portmaster.
-<br/>
+You'll need A copy of the black gate and/or serpent isle added to ports/exult/data/blackgate and/or ports/exult/data/serpentisle. 
+
+If done correctly there will be a ports/exult/data/blackgate/static and ports/exult/data/serpentisle/static folder. 
+
+You’ll also need a copy of an existing saved game or you won’t be able to start a game session. 
+
+
+Thanks to the [Exult Team](https://github.com/exult/exult) for the Exult engine that makes this possible.  
+
 

--- a/markdown/flare.md
+++ b/markdown/flare.md
@@ -1,6 +1,9 @@
 ## Notes
-<br/>
+
+More games can be downloaded from https://flarerpg.org/mods and placed in the ports/flare/mods folder
 
 Thanks to the [Flare team](https://github.com/flareteam/flare-engine) for creating the game.  Also thanks to Cebion for the packaging for portmaster.
-<br/>
+
+
+
 

--- a/markdown/freedom.planet.md
+++ b/markdown/freedom.planet.md
@@ -1,3 +1,18 @@
 ## Notes
-<br/>
+
+Be sure the freedomplanet/gamedata folder on you sd card contains subfolders named bin32, bin64 and Data. 
+
+The runtime folder and the run.sh file is not needed and should be left out or it will cause a double entry for Freedom Planet in the ports section of Emulationstation. 
+
+There should also be a filed named Assets.dat in freedomplanet/gamedata as well. 
+
+Then run Freedom Planet from the Emulationstation ports menu.
+Note: This game can take a minute or two to initially load.
+
+
+
+Thanks to ptitSeb for box86 (https://github.com/ptitSeb/box86)
+Thanks to JohnnyonFlame for gl4es and the the necessary packaging to allow this game to run on supported linux distros. (https://github.com/JohnnyonFlame/gl4es/tree/sk_hacks)
+
+
 

--- a/markdown/iconoclasts.md
+++ b/markdown/iconoclasts.md
@@ -1,9 +1,19 @@
 ## Notes
-<br/>
+
+* For Steam or Preinstalled GOG:
+
+				* Copy data into the ports/iconoclasts/gamedata folder
+				* Be sure the folder contains subfolders named 32, 64 and data
+* Alternatively, from GOG's self-installer:
+
+				* Rename the installer (e.g. iconoclasts_1_15_chinese_24946.sh) extension from .sh to .gz
+				* Then use 7zip to open the installer and grab the contents of the game folder (bin32, bin64, data and Assets.dat) and place it in the ports/iconoclasts/gamedata folder
+
 
 **This game is best played on devices with a 640x480 screen resolution or higher!**
 
 Thanks to JohnnyonFlame for [gl4es](https://github.com/ptitSeb/gl4es/pull/362) and the [necessary packaging](https://github.com/JohnnyonFlame/BoxofPatches) to allow this game to run on portmaster.
 You can donate towards JohnnyonFlame's work [here](https://ko-fi.com/johnnyonflame)
-<br/>
+
+
 

--- a/markdown/iortcw.md
+++ b/markdown/iortcw.md
@@ -1,7 +1,8 @@
 ## Notes
-<br/>
 
-Thanks to [Donny Springer, Zack Middleton, James Canete and other contributors](https://github.com/iortcw/iortcw) for this engine.  Also thanks to [JohnnyonFlame](https://github.com/JohnnyonFlame/handheld-iortcw) for the porting work for portmaster and romadu for the packaging for portmaster.
-You can donate towards JohnnyonFlame's work [here](https://ko-fi.com/johnnyonflame)
-<br/>
+The Steam version seems to work best as it's patched for Linux use already.
+
+Thanks to [Donny Springer, Zack Middleton, James Canete and other contributors](https://github.com/iortcw/iortcw) for this engine. 
+
+
 

--- a/markdown/mightymike.md
+++ b/markdown/mightymike.md
@@ -1,6 +1,9 @@
 ## Notes
-<br/>
+
+Currently only runs on the RG552 with Jelos installed.
 
 Thanks to Pangea Software for creating the game and publicly releasing the game files. Thanks to [Jorio](https://github.com/jorio/MightyMike) for porting the game engine to various platforms.  Also thanks to brooksytech for the porting work for portmaster.
-<br/>
+
+
+
 

--- a/markdown/moonlight.md
+++ b/markdown/moonlight.md
@@ -1,6 +1,32 @@
 ## Notes
-<br/>
+
+C Requirements and setup as follows:
+
+PC Requirements:
+A PC with an Nvidia 600 GPU or newer
+GeForce Experience app
+
+* You'll need to make sure your streaming PC and your rk3326 device with the supported linux distro are connected to the same network.
+* When you launch Moonlight from the ports menu, you'll be presented with a menu with 2 options, Start Streaming and settings. You'll want to go to settings first and choose the pair option.
+* You'll be presented with a screen asking for the name or IP address of your PC with the Nvidia Geforce Experience app installed.
+* Once you hit the ok button, you should be presented with a pairing dialog box on your PC.
+* Enter the 4 digit PIN displayed on your device into the pairing dialog box and click the Connect button.
+* By default, Moonlight is setup to stream Steam from your PC. There are other options available such as Dolphin if you have that installed and configured on your PC.
+* Notes:
+* 
+* To ensure that you have controls in your games while streaming, be sure to disconnect any game controllers from your PC and reboot your PC before you start your streaming session.
+* More information about Moonlight is available here.
+* If you experience issues with the setup and launching menu functioning correctly, hitting start may resolve it or simply force close the port using the usual exit hotkey on ArkOS or supported linux distro for your device (RGB10 = Minus + Start, RK2020/RG351P/M/V/MP = Select+Start, Chi = 1 + Start).
+* For those that don't have an Nvidia vide card, there's an alternative PC client called Sunshine. I haven't tested it so I don't know how well it will work but there's been reports that it seems to work well.
+* To exit Moonlight when complete, you can press Select+Start+L1+R1 or simply use the exit hotkey for your device to get out of the app.
+* If you experience issues reconnecting to your PC, go to settings in the Moonlight app and unpair the PC then do another pair again.
+* There has been an instance where Moonlight would not work with a PC unless the HDMI connection was removed from the PC to a TV.
+* You can add more apps for streaming by editing the Moonlight.sh file and adding more apps between lines 167 and 173. Be aware that the entries are case sensitive.
+* Mouse control is only possible using the Rockchip platform in settings. That is only possible on the OGA, OGS, RGB10, and the RK2020 at this time. Holding start for about 2 - 3 seconds while using the Rockchip platform will switch to mouse mode. Hold Start for about 2 - 3 seconds again to switch back to gamepad controls.
+
+
 
 Thanks to the [moonlight-stream](https://github.com/moonlight-stream/moonlight-embedded) team for creating this solution that makes it possible.  Also thanks to [AreaScout](https://github.com/AreaScout/moonlight-embedded) for the necessary modifications that make this possible to run on portmaster.
-<br/>
+
+
 

--- a/markdown/openrct2.md
+++ b/markdown/openrct2.md
@@ -1,6 +1,10 @@
 ## Notes
-<br/>
+
+They can be bought at either [Steam](https://store.steampowered.com/app/285330/) or [GOG.com](https://www.gog.com/game/rollercoaster_tycoon_2). If you have the original RollerCoaster Tycoon and its expansion packs, you can point OpenRCT2 to these in order to play the original scenarios
 
 Thanks to [OpenRCT2 team](https://github.com/OpenRCT2/OpenRCT2) for creating this opensource port.  Also thanks to [kloptops](https://github.com/kloptops/Portmaster-misc/tree/main/OpenRCT2) for the porting work for portmaster.
-<br/>
+
+
+
+
 

--- a/markdown/openxcom.md
+++ b/markdown/openxcom.md
@@ -1,7 +1,12 @@
 ## Notes
-<br/>
+
+UFO Defense game data goes in the UFO folder, Terror from the deep goes in the TFTD folder, any mods go in the mods folder. 
 
 **Never enable OpenGL or it will crash immediately on loading (which can be fixed by editing the .cfg file and turning it back off there)**
+
+
 Thanks to [MeridianOXC](https://github.com/MeridianOXC/OpenXcom) and contributors for the open-source ports that makes this possible.  Also thanks to nl255 for the porting work for portmaster.
-<br/>
+
+
+
 

--- a/markdown/ottomatic.md
+++ b/markdown/ottomatic.md
@@ -1,6 +1,9 @@
 ## Notes
-<br/>
 
-Thanks to Pangea Software for creating the game and publicly releasing the game files. Thanks to [Jorio](https://github.com/jorio/ottomatic) for porting the game engine to various platforms.  Also thanks to brooksytech for the porting work for portmaster.
-<br/>
+Currently only runs on the RG552 with Jelos installed.
+
+
+Thanks to Pangea Software for creating the game and publicly releasing the game files. Thanks to [Jorio](https://github.com/jorio/ottomatic) for porting the game engine to various platforms.  
+
+
 

--- a/markdown/prototype.md
+++ b/markdown/prototype.md
@@ -1,0 +1,5 @@
+## Notes
+
+Notes: A big thanks to [ptitSeb](https://github.com/ptitSeb/prototype) for creating this opensource port. 
+
+

--- a/markdown/shovel.knight.md
+++ b/markdown/shovel.knight.md
@@ -1,10 +1,16 @@
 ## Notes
-<br/>
 
-**For PortMaster version, copy your Shovel Knight Treasure Trove for Linux folder to the ports/shovelknight/gamedata folder.  You should have ports/shovelknight/gamedata/shovelknight folder structure with additional subfolders such as 32, 64, and data within ports/shovelknight/gamedata/shovelknight.  Once done, just run Shovel Knight.sh.
+1. Be sure the folder contains subfolders named 32, 64 and data. There should also be a filed named ShovelKnight.
+2. Copy the shovelknight folder to the roms/ports folder on your device.
+
+
+For PortMaster version, copy your Shovel Knight Treasure Trove for Linux folder to the ports/shovelknight/gamedata folder.  You should have ports/shovelknight/gamedata/shovelknight folder structure with additional subfolders such as 32, 64, and data within ports/shovelknight/gamedata/shovelknight.  Once done, just run Shovel Knight.sh.
 
 Thanks to ptitSeb for box86 (https://github.com/ptitSeb/box86)
 Thanks to JohnnyonFlame for gl4es and the necessary packaging to allow this game to run on supported linux distros. (https://github.com/JohnnyonFlame/gl4es/tree/sk_hacks)
 You can donate towards JohnnyonFlame's work [here](https://ko-fi.com/johnnyonflame)
-<br/>
+
+
+
+
 

--- a/markdown/sonic.1.md
+++ b/markdown/sonic.1.md
@@ -1,6 +1,15 @@
 ## Notes
-<br/>
+
+You must have a copy of the Sonic The Hedgehog Classic Android APK then do the following:
+
+1. Using 7Zip, open the apk and extract /assets/Data.rsdk.xmf.
+2. Rename the Data.rsdk.xmf to Data.rsdk. Case is important!
+3. Copy the Data.rsdk file to the ports/sonic1 folder.
+4. If all is well, you should be able to run Sonic 1 now.
+5. For a video of what to do, check out Retro Game Corps' video guide here.
 
 Thanks to [Rubberduckycooly](https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation) for the decompilation work that makes this possible.
-<br/>
+
+
+
 

--- a/markdown/sonic.2.md
+++ b/markdown/sonic.2.md
@@ -1,6 +1,17 @@
 ## Notes
-<br/>
+
+You must have a copy of the Sonic The Hedgehog Classic Android APK then do the following:
+
+1. Using 7Zip, open the apk and extract /assets/Data.rsdk.xmf.
+2. Rename the Data.rsdk.xmf to Data.rsdk. Case is important!
+3. Copy the Data.rsdk file to the ports/sonic2 folder.
+4. If all is well, you should be able to run Sonic 2 now.
+5. For a video of what to do, check out Retro Game Corps' video guide here.
+
 
 Thanks to [Rubberduckycooly](https://github.com/Rubberduckycooly/Sonic-1-2-2013-Decompilation) for the decompilation work that makes this possible.
-<br/>
+
+
+
+
 

--- a/markdown/sonic.cd.md
+++ b/markdown/sonic.cd.md
@@ -1,6 +1,17 @@
 ## Notes
-<br/>
+
+ You must have a copy of the Sonic CD Classic Android APK then do the following:
+
+1. Using 7Zip, open the apk and extract Androind/obb/comm.sega.soniccd.classic/patch49.com.sega.soniccd.classic.obb.
+2. This file may have a different number such as patch56 or higher which should also work as well.
+3. Rename the patch49.com.sega.soniccd.classic.obb to Data.rsdk. Case is important!
+4. Copy the Data.rsdk file to the ports/soniccd folder.
+5. If all is well, you should be able to run Sonic CD now.
+6. For a video of what to do, check out Retro Game Corps' video guide here.
+Note: There seems to be an issue with being able to consistently exit Sonic CD through the menu like you can with Sonic 1 and 2. You can exit Sonic CD by holding Select and pressing Start. (For the RGB10, you can hold Minus and press Start. For the Chi, you can hold the 1 key and press Start.)
+
 
 Thanks to [Rubberduckycooly](https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation) for the decompilation work that makes this possible.
-<br/>
+
+
 

--- a/markdown/sorr.md
+++ b/markdown/sorr.md
@@ -1,7 +1,16 @@
 ## Notes
-<br/>
 
 Thanks to [josebagar](https://gitlab.com/josebagar/bennugd-monolithic) for the update to the bennugd-monolithic that made this possible.
 Thanks to [isage](https://github.com/isage/sorr-vita) for the slow down fix that benefits this platform.
-<br/>
+
+
+## Detailed Instructions
+
+1. Obtain any version of SorR. You can use either the windows or linux/debian version it does not matter which.
+
+2. Extract them /roms/ports/sorr (For RG351V if using SD2, extract to /roms2/ports/sorr instead). You should have a /mod folder, a /palettes folder, and SorR.dat file in this location in order for the game to work.
+
+3. Then go to Ports, and launch SorR
+Note: If you experience a slowdown in gameplay after sometime, force exit the game (You can use the normal force exit hotkey combination for your device), then start the game again and it will start from the beginning of the last stage you were on and be full speed for a few more stages. It's the best workaround for the issue for now until someone can figure out and resolve the root cause of the slowdown. [Fixed as of 10/6/2021]
+
 

--- a/markdown/srb2.md
+++ b/markdown/srb2.md
@@ -1,6 +1,12 @@
 ## Notes
-<br/>
+
+To use mods and addons for SRB2, just add the relevant files to ports/SRB2/conf/.srb2/addons and load them using Add Ons menu item while in the game.
 
 Thanks to [Sonic Team Junior](https://github.com/STJr/SRB2) for creating this opensource fan game.  Also thanks to romadu for the packaging for portmaster.
-<br/>
+
+
+
+
+
+
 

--- a/markdown/stardewvalley.md
+++ b/markdown/stardewvalley.md
@@ -1,9 +1,14 @@
 ## Notes
-<br/>
 
 Thanks to the [MonoGame](https://github.com/MonoGame/MonoGame) project for the framework that's used to make this possible.
 Thanks to JohnnyonFlame for the port work that makes this possible.
-You can donate towards MonoGame's work [here](https://www.monogame.net/donate/)
-You can donate towards JohnnyonFlame's work [here](https://ko-fi.com/johnnyonflame)
-<br/>
+
+## Detailed Instructions
+
+You must have a copy of the [compatibility version](https://www.stardewvalley.net/compatibility/) of Stardew Valley. 
+
+Steam or GOG versions should work. If purchasing the game, have in mind that there is no GOG compatibility version for linux, as that requires using GOG Galaxy, which doesn't support linux at all. 
+
+Windows compatibility version works fine. Copy data into the ports/stardewvalley/gamedata folder
+
 

--- a/markdown/super.mario.war.md
+++ b/markdown/super.mario.war.md
@@ -1,6 +1,16 @@
 ## Notes
-<br/>
 
 Thanks to [Mátyás Mustoha](https://github.com/mmatyas/supermariowar) for continuing the work originally started by Samuele Poletto and then Florian Hufsky to make this game what it is today.
-<br/>
+
+
+## Netplay Instructions
+
+Netplay: There's a netplay feature available with the portmaster version that supports network play between multiple units. According to the author (mmatyas) of this feature, it is very much experimental so performance will vary depending on a a number of factors not limited to network latency, connection quality (2.4Ghz vs 5Ghz, vs Wired connection) and if attempting to play over Internet, lag and disconnects. To use this feature: you can do the following:
+
+One of players has to run the server. This can be done from the netplay menu provided when you launch Super Mario War from the PortMaster version.
+Server IPs can be added from the netplay menu from within settings. The netplay menu will allow you to easily set Server 1 as your internal IP address, Server 2 as your external IP address. You can also set alternative addresses for these servers as well.
+Make sure to start the server before you start Super Mario War. Once started, you can join the server using your internal IP address. The other players will need to join via your internal IP if playing on the same local network or your external IP if joining via Internet.
+Be aware that if playing over internet, the unit with the smw server started must have port forwarding on that wifi or wired router's configuration for UDP 12521 to point to the internal IP of the unit running the smw server. If this is not done, Internet based players may not be able to join the smw server.
+Once connected, a room must be created with a name. With the PortMaster setup, the x and y button can be used to just name the room x or y so the room can be setup and all players can enter the room and start playing.
+
 

--- a/markdown/tamatool.md
+++ b/markdown/tamatool.md
@@ -1,6 +1,10 @@
 ## Notes
-<br/>
+
+The expected ROM format is 16 bits in big-endian per instruction (the actual E0C6S46 instructions are 12-bit long).
 
 Thanks to [Tamatool](https://github.com/jcrona/tamatool) for this Tamagotchi P1 explorer.  Also thanks to Bamboozler for the porting work for portmaster.
-<br/>
+
+
+
+
 

--- a/markdown/tileworld.md
+++ b/markdown/tileworld.md
@@ -1,6 +1,10 @@
 ## Notes
-<br/>
+
+To play the original Chip's Challenge levels, copy your chips.dat file into ports/tileworld/data folder and make sure it's lowercase. 
 
 Thanks to [Ricardo Angeli](https://github.com/rangeli/tileworld) for this emulation port of Chip's Challenge created by Chuck Sommerville.  Also thanks to Slayer366 for the porting work for portmaster.
-<br/>
+
+
+
+
 

--- a/markdown/vanillara.md
+++ b/markdown/vanillara.md
@@ -1,6 +1,12 @@
 ## Notes
-<br/>
+
+If you want to play the full version, you will need to place at least MAIN.MIX & READALERT.MIX into ports/vanillara/data/vanillara. 
+
+You can get the game files from [here](https://github.com/TheAssemblyArmada/Vanilla-Conquer#vanillatd-and-vanillara). For multiple cd's for the campaigns & expansions it is a little more complex. Follow the installation instructions from here.<br>  If you want to use the expansions you will need the files from the patch 3.03, available [here](https://github.com/TheAssemblyArmada/Vanilla-Conquer/wiki/Installing-VanillaRA).
+
 
 Thanks to [TheAssemblyArmada](https://github.com/TheAssemblyArmada/Vanilla-Conquer) and other contributors for the build.  Also thanks to kloptops and Snoopy from the AmberElec Discord for the porting work.
-<br/>
+
+
+
 

--- a/markdown/vanillatd.md
+++ b/markdown/vanillatd.md
@@ -1,6 +1,10 @@
 ## Notes
-<br/>
+
+If you want to play the full version, you will need to place the game files from the following guide into ports/vanillatd/data/vanillatd. <br>   You will need to delete all the game files in ports/vanillatd/data/vanillatd before installing full game files.
 
 Thanks to [Vanilla Conquer](https://github.com/TheAssemblyArmada/Vanilla-Conquer) and other contributors for the build.  Also thanks to kloptops and Snoopy from the AmberElec Discord for the porting work.
-<br/>
+
+
+
+
 

--- a/markdown/vcmi.md
+++ b/markdown/vcmi.md
@@ -1,6 +1,11 @@
 ## Notes
-<br/>
 
 Thanks to [VCMI Team](https://github.com/vcmi/vcmi) for the open source Heroes of Might and Magic III engine that makes this possible.  Also thanks to the [kloptops](https://github.com/kloptops/Portmaster-misc/tree/main/VCMI) for the porting work for portmaster.
-<br/>
+
+## Detailed Instructions
+
+You need to add required game files either from CD1 & CD2, GoG or an installed copy of the game. <br>  This requires about 2-3 gb of free space. For the gog version copy setup_heroes_of_might_and_magic_3_complete_4.0_(28740)-1.bin and setup_heroes_of_might_and_magic_3_complete_4.0_(28740).exe into ports/vcmi. <br>  For the cd version copy the contents of cd1 into ports/vcmi/cd1 and cd2 into ports/vcmi/cd2. For the installed version copy installed game files into ports/vcmi/install.
+
+
+
 

--- a/markdown/yatka.md
+++ b/markdown/yatka.md
@@ -1,6 +1,10 @@
 ## Notes
-<br/>
+
+To force an higher resolution add --scale2x or higher in the boot script
 
 Thanks to [szymor](https://github.com/szymor/yatka) for the source code.  Also thanks to Tekkenfede for the packaging for portmaster.
-<br/>
+
+
+
+
 


### PR DESCRIPTION
Old github wiki should now be on par with information on the new PortMaster Wiki https://portmaster.games/wiki.html

All new Ports PRs must have a portname.md with Credits, Control section and additioinal notes.
This will also be added to the PR check.

