### PR TITLE
Rebuild Doom 3 port from newest upstream

### DIFF
--- a/markdown/doom3.md
+++ b/markdown/doom3.md
@@ -1,6 +1,61 @@
 ## Notes
-<br/>
 
-Thanks to [Gabriel Cuvillier](https://github.com/gabrielcuvillier/d3wasm) for the d3wasm engine. Also thanks to brooksytech for the porting and packaging for portmaster.
-<br/>
+This port is based on the work of [Emile Belanger](https://github.com/emileb/d3es-multithread), which is in turn based on the work of [Gabriel Cuvillier](https://github.com/gabrielcuvillier/d3wasm) and [Daniel Gibson](https://github.com/dhewm/dhewm3) for the dhewm3 port. Many thanks!
+ 
+Also thanks to brooksytech for the porting and packaging for portmaster.
 
+## Controls
+
+See the file `doom3/default_controls_doom3.png` in doom3.zip. For some reason the back button binding to open the menu does not work, so use the shortcut `back button + B button` instead.
+
+## Build Instructions
+
+[d3es](https://github.com/emileb/d3es-multithread) for this port was compiled using an aarch64 Ubuntu Focal Docker container running on an amd64 Debian Bookworm host.
+
+If you would like to compile an updated version, here are the steps.
+
+### Clone the source repsitory
+Use git to clone the [d3es repository](https://github.com/emileb/d3es-multithread):
+```
+git clone https://github.com/emileb/d3es-multithread.git
+cd d3es-multithread
+```
+
+### Install Docker
+Follow the steps to [Install Docker Engine on Debian using the apt repository](https://docs.docker.com/engine/install/debian/#install-using-the-repository) 
+ 
+### Docker post-install steps
+Follow the steps at [Configure Docker on your Linux host](https://docs.docker.com/engine/install/linux-postinstall/) to manage Docker as a non-root user.
+ 
+### Install multiarch/qemu-user-static
+This will enable execution of different multi-architecture containers by QEMU and binfmt_misc:
+```
+sudo apt install binfmt-support qemu-user-static
+```
+
+### aarch64 Ubuntu Focal Docker container
+Use multiarch/qemu-user-static to run an aarch64 Ubuntu Focal Docker container. Mount the d3es-multithread directory as a volume to `/data` - assumed to be `$(pwd)`.
+```
+docker run --rm --privileged multiarch/qemu-user-static:register
+docker run -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static -it --platform linux/arm64 -v $(pwd):/data ubuntu:focal
+```
+
+### Compile d3es-multithread
+Install the d3es-multithread build dependencies and compile following the instructions at [Compiling](https://github.com/emileb/d3es-multithread#compiling):
+
+```
+// Install build dependencies
+apt install git cmake build-essential libsdl2-dev libopenal-dev zlib1g-dev libcurl4-openssl-dev
+
+// Create build directory
+mkdir build && cd build
+
+// Have a look at supported cmake options
+cmake -LH ../neo/
+
+// Create a makefile with cmake - pass arguments for cmake options as desired
+cmake ../neo/ -DONATIVE=ON
+
+// Compile - choose how many threads you want it to use
+make -j12
+```

--- a/markdown/doom3.md
+++ b/markdown/doom3.md
@@ -15,6 +15,7 @@ See the file `doom3/default_controls_doom3.png` in doom3.zip. For some reason th
 If you would like to compile an updated version, here are the steps.
 
 ### Clone the source repsitory
+
 Use git to clone the [d3es repository](https://github.com/emileb/d3es-multithread):
 ```
 git clone https://github.com/emileb/d3es-multithread.git
@@ -22,18 +23,22 @@ cd d3es-multithread
 ```
 
 ### Install Docker
+
 Follow the steps to [Install Docker Engine on Debian using the apt repository](https://docs.docker.com/engine/install/debian/#install-using-the-repository) 
  
 ### Docker post-install steps
+
 Follow the steps at [Configure Docker on your Linux host](https://docs.docker.com/engine/install/linux-postinstall/) to manage Docker as a non-root user.
  
 ### Install multiarch/qemu-user-static
+
 This will enable execution of different multi-architecture containers by QEMU and binfmt_misc:
 ```
 sudo apt install binfmt-support qemu-user-static
 ```
 
 ### aarch64 Ubuntu Focal Docker container
+
 Use multiarch/qemu-user-static to run an aarch64 Ubuntu Focal Docker container. Mount the d3es-multithread directory as a volume to `/data` - assumed to be `$(pwd)`.
 ```
 docker run --rm --privileged multiarch/qemu-user-static:register
@@ -41,6 +46,7 @@ docker run -v /usr/bin/qemu-aarch64-static:/usr/bin/qemu-aarch64-static -it --pl
 ```
 
 ### Compile d3es-multithread
+
 Install the d3es-multithread build dependencies and compile following the instructions at [Compiling](https://github.com/emileb/d3es-multithread#compiling):
 
 ```
@@ -58,4 +64,17 @@ cmake ../neo/ -DONATIVE=ON
 
 // Compile - choose how many threads you want it to use
 make -j12
+```
+
+### Test
+Replace the following files in `ports/doom3` on your device with the newly compiled versions:
+```
+base.so
+d3xp.so
+dhewm3
+```
+
+Ensure `dhewm3` is executable:
+```
+chmod a+x ./dhewm3
 ```


### PR DESCRIPTION
Updated port for Doom 3 - rebuild from latest upstream commit (4f35e6ad2acafb936b784a9d33c8383864ce91a8)

URL: https://github.com/emileb/d3es-multithread

Doom 3

Notes: Built in Ubuntu Focal aarch64 Docker container

Tested on Odroid Go Ultra - JELOS

Further testing notes on [Discord](https://discord.com/channels/1122861252088172575/1200409261986021567/1200409261986021567)